### PR TITLE
Fixes

### DIFF
--- a/FedoraMirrorGrabber.Core/MirrorListRetriever.cs
+++ b/FedoraMirrorGrabber.Core/MirrorListRetriever.cs
@@ -10,6 +10,10 @@ public class MirrorListRetriever
 
   #endregion
 
+  /// <summary>
+  ///   Host the request will be sent to.
+  /// </summary>
+  /// <remarks>Defaults to <see cref="Host"/>.</remarks>
   public Uri BaseAddress { get; set; }
 
   #region Constructors
@@ -27,7 +31,7 @@ public class MirrorListRetriever
 
   public async Task<IEnumerable<Mirror>> GetMirrors(string baseArch, int releaseVersion)
   {
-    _client.BaseAddress = new Uri("https://mirrors.fedoraproject.org/");
+    _client.BaseAddress = BaseAddress;
     var content = await _client.GetStringAsync($"metalink?repo=fedora-{releaseVersion}&arch={baseArch}");
 
     return _processor.Run(content);

--- a/FedoraMirrorGrabber.sln
+++ b/FedoraMirrorGrabber.sln
@@ -9,12 +9,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
 		LICENSE = LICENSE
+		Nuget.config = Nuget.config
 		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FedoraMirrorGrabber.Core", "FedoraMirrorGrabber.Core\FedoraMirrorGrabber.Core.csproj", "{E56FC10E-ECB0-4511-8DEB-91DF2AF501E2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FedoraMirrorGrabber.Core.Tests", "FedoraMirrorGrabber.Core.Tests\FedoraMirrorGrabber.Core.Tests.csproj", "{80D8EB4E-23C0-4F7A-B7D9-F1AB0D957B41}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FedoraMirrorGrabber.Core.Tests", "FedoraMirrorGrabber.Core.Tests\FedoraMirrorGrabber.Core.Tests.csproj", "{80D8EB4E-23C0-4F7A-B7D9-F1AB0D957B41}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Nuget.config
+++ b/Nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet" value="https://www.nuget.org/api/v2/" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
- Use `HttpClient.BaseAddress` from `MirrorListRetriever.BaseAddress`
- Use `WireMock` server in tests